### PR TITLE
Use strdup consistently

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -177,7 +177,7 @@ static int load(mdns_daemon_t *d, char *path, char *hostname)
 	}
 
 	if (!srec.name)
-		srec.name = hostname;
+		srec.name = strdup(hostname);
 	if (!srec.type)
 		srec.type = strdup("_http._tcp");
 


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/troglobit/mdnsd/pull/27 which, under certain circumstances, would have invoked free() on something that wasn't malloc()ed.